### PR TITLE
Fix remove_template_string option bugs

### DIFF
--- a/lua/template-string/config.lua
+++ b/lua/template-string/config.lua
@@ -1,4 +1,4 @@
-local U = require('template-string.utils')
+local U = require("template-string.utils")
 local M = {}
 
 M.options = {

--- a/lua/template-string/init.lua
+++ b/lua/template-string/init.lua
@@ -1,7 +1,7 @@
 local U = require("template-string.utils")
 local C = require("template-string.config")
-local quote = require('template-string.quote_string')
-local template = require('template-string.template_string')
+local quote = require("template-string.quote_string")
+local template = require("template-string.template_string")
 local augroup = vim.api.nvim_create_augroup
 local autocmd = vim.api.nvim_create_autocmd
 
@@ -20,9 +20,6 @@ function M.handle_type()
 	elseif C.options.remove_template_string then
 		template.handle_template_string(node, buf)
 	end
-end
-
-function M.handle_filetype()
 end
 
 function M.setup(options)

--- a/lua/template-string/init.lua
+++ b/lua/template-string/init.lua
@@ -34,7 +34,7 @@ function M.setup(options)
 				return
 			end
 
-			autocmd("TextChangedI", {
+			autocmd({ "TextChanged", "TextChangedI" }, {
 				group = M.group,
 				buffer = ev.buf,
 				callback = M.handle_type,

--- a/lua/template-string/quote_string.lua
+++ b/lua/template-string/quote_string.lua
@@ -2,11 +2,23 @@ local U = require("template-string.utils")
 local C = require("template-string.config")
 local M = {}
 
+function M.is_already_template(text)
+	return text:match("^{?`.*`}?$") ~= nil
+end
+
 function M.handle_quote_string(node, buf)
 	local text = vim.treesitter.get_node_text(node, buf)
 
-	-- stylua: ignore
-	if not U.has_template_string(text) then return end
+	if
+		U.is_undo_or_redo()
+		or not U.has_template_string(text)
+		-- ignore last redo
+		or M.is_already_template(text)
+		-- ignore multiline quote string (treesitter could detect quote string in bad syntax)
+		or U.is_multiline(text)
+	then
+		return
+	end
 
 	local new_text = U.replace_quotes(text, U.quote.BACKTICK)
 

--- a/lua/template-string/template_string.lua
+++ b/lua/template-string/template_string.lua
@@ -16,11 +16,33 @@ function M.is_tag_function(node)
 	return node:parent():type() == "call_expression"
 end
 
+---return if the given string node has manual backticks
+---considering manual backticks when never were template substitutions (${})
+---@param node userdata tsnode
+---@return boolean
+function M.manual_backticks(node)
+	local child_count = node:named_child_count()
+
+	return child_count == 0
+end
+
+---@param str string
+---@return boolean
+function M.has_quotes(str)
+	return str:match("[\"']") ~= nil
+end
+
 function M.handle_template_string(node, buf)
 	local text = vim.treesitter.get_node_text(node, buf)
 
 	-- backticks must be kept on these cases
-	if U.has_template_string(text) or M.is_multiline(text) or M.is_tag_function(node) then
+	if
+		U.has_template_string(text)
+		or M.has_quotes(text)
+		or M.is_multiline(text)
+		or M.manual_backticks(node)
+		or M.is_tag_function(node)
+	then
 		return
 	end
 

--- a/lua/template-string/template_string.lua
+++ b/lua/template-string/template_string.lua
@@ -2,12 +2,6 @@ local U = require("template-string.utils")
 local C = require("template-string.config")
 local M = {}
 
----@param str	string
----@return boolean
-function M.is_multiline(str)
-	return str:match("\n") ~= nil
-end
-
 ---return if the given string node is part of a tag function
 ---e.g - css`some text`
 ---@param node userdata tsnode
@@ -39,7 +33,7 @@ function M.handle_template_string(node, buf)
 	if
 		U.has_template_string(text)
 		or M.has_quotes(text)
-		or M.is_multiline(text)
+		or U.is_multiline(text)
 		or M.manual_backticks(node)
 		or M.is_tag_function(node)
 	then

--- a/lua/template-string/utils.lua
+++ b/lua/template-string/utils.lua
@@ -8,6 +8,13 @@ M.quote = {
 	BACKTICK = [[`]],
 }
 
+--- NOTE: this doesn't detect the last redo
+function M.is_undo_or_redo()
+	local tree = vim.fn.undotree()
+
+	return tree.seq_cur ~= tree.seq_last
+end
+
 ---find the closest outward string node from the cursor and return if found
 function M.get_string_node()
 	local node = ts_utils.get_node_at_cursor()
@@ -27,22 +34,28 @@ function M.get_string_node()
 	end
 end
 
+---@param str	string
+---@return boolean
+function M.is_multiline(str)
+	return str:match("\n") ~= nil
+end
+
 ---@param str string
 ---@return boolean
 function M.has_template_string(str)
 	return str:match("${.*}") ~= nil
 end
 
----return if given node is part of a jsx attribute
+---know if given node must be handled as part of a JSX attribute
 ---@param node userdata tsnode
 ---@return boolean
 function M.is_jsx_node(node)
 	local parent_types = {
-		"jsx_attribute",
-		"jsx_expression",
+		string = "jsx_attribute",
+		template_string = "jsx_expression",
 	}
 
-	return vim.tbl_contains(parent_types, node:parent():type())
+	return parent_types[node:type()] == node:parent():type()
 end
 
 ---@param str string


### PR DESCRIPTION
This should fix these bugs:

1. Registry changes on normal mode
2. Only remove backticks if there was a template substitution (${}) inside the string
3. Ignore multiline detections on quote strings, (isn't valid syntax but Treesitter detects it like a string node so must be ignored)
4. Not remove backticks if there are quotes inside the text (let that decision to the user)

fix: #3 