### PR TITLE
feat(#7): support JS in HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Example with the default config. If you prefer, you could call the setup functio
 
 ```lua
 require('template-string').setup({
-  filetypes = { 'typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'python' }, -- filetypes where the plugin is active
+  filetypes = { 'html', 'typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'python' }, -- filetypes where the plugin is active
   jsx_brackets = true, -- must add brackets to jsx attributes
   remove_template_string = false, -- remove backticks when there are no template string
   restore_quotes = {

--- a/lua/template-string/config.lua
+++ b/lua/template-string/config.lua
@@ -2,7 +2,7 @@ local U = require("template-string.utils")
 local M = {}
 
 M.options = {
-	filetypes = { "typescript", "javascript", "typescriptreact", "javascriptreact", "python" },
+	filetypes = { "html", "typescript", "javascript", "typescriptreact", "javascriptreact", "python" },
 	jsx_brackets = true,
 	remove_template_string = false,
 	restore_quotes = {

--- a/lua/template-string/utils.lua
+++ b/lua/template-string/utils.lua
@@ -6,7 +6,13 @@ M.quote = {
 	BACKTICK = [[`]],
 }
 
-M.get_cusor_node = vim.treesitter.get_node or require("nvim-treesitter.ts_utils").get_node_at_cursor
+function M.get_cusor_node()
+    if vim.treesitter.get_node then
+        return vim.treesitter.get_node({ ignore_injections = false })
+    else
+        return require("nvim-treesitter.ts_utils").get_node_at_cursor()
+    end
+end
 
 --- NOTE: this doesn't detect the last redo
 function M.is_undo_or_redo()


### PR DESCRIPTION
use ignore_injections = true with treesitter to support js in html. also adds html as a default filetype for the plugin.

not sure if you want to add any changes to the plugin because it'll now run on an html filetype, but it works fine as far as I can tell.