### PR TITLE
feat: add vue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Opposite function, remove backticks when there are no template strings
 - Javascript / Typescript
 - JSX
 - Vue
+- Svelte
 - Python
 
 ## Configuration
@@ -45,7 +46,7 @@ Example with the default config. If you prefer, you could call the setup functio
 
 ```lua
 require('template-string').setup({
-  filetypes = { 'html', 'typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue', 'python' }, -- filetypes where the plugin is active
+  filetypes = { 'html', 'typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue', 'svelte', 'python' }, -- filetypes where the plugin is active
   jsx_brackets = true, -- must add brackets to JSX attributes
   remove_template_string = false, -- remove backticks when there are no template strings
   restore_quotes = {

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Opposite function, remove backticks when there are no template strings
 
 - Javascript / Typescript
 - JSX
+- Vue
 - Python
 
 ## Configuration
@@ -44,7 +45,7 @@ Example with the default config. If you prefer, you could call the setup functio
 
 ```lua
 require('template-string').setup({
-  filetypes = { 'html', 'typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'python' }, -- filetypes where the plugin is active
+  filetypes = { 'html', 'typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue', 'python' }, -- filetypes where the plugin is active
   jsx_brackets = true, -- must add brackets to JSX attributes
   remove_template_string = false, -- remove backticks when there are no template strings
   restore_quotes = {

--- a/lua/template-string/config.lua
+++ b/lua/template-string/config.lua
@@ -2,7 +2,7 @@ local U = require("template-string.utils")
 local M = {}
 
 M.options = {
-	filetypes = { "html", "typescript", "javascript", "typescriptreact", "javascriptreact", "vue", "python" },
+	filetypes = { "html", "typescript", "javascript", "typescriptreact", "javascriptreact", "vue", "svelte", "python" },
 	jsx_brackets = true,
 	remove_template_string = false,
 	restore_quotes = {

--- a/lua/template-string/config.lua
+++ b/lua/template-string/config.lua
@@ -2,7 +2,7 @@ local U = require("template-string.utils")
 local M = {}
 
 M.options = {
-	filetypes = { "html", "typescript", "javascript", "typescriptreact", "javascriptreact", "python" },
+	filetypes = { "html", "typescript", "javascript", "typescriptreact", "javascriptreact", "vue", "python" },
 	jsx_brackets = true,
 	remove_template_string = false,
 	restore_quotes = {


### PR DESCRIPTION
Hello, Axel, I really like the plugin you've created, it's very convenient!

I previously inquired about using this plugin in Vue, as mentioned in issue #14. I tried adding "vue" to the filetype setting, but unfortunately, it didn't work.

This is my LazyVim configuration.
```javascript
{
	"axelvc/template-string.nvim",
	event = "InsertEnter",
	ft = {
		"javascript",
		"typescript",
		"javascriptreact",
		"typescriptreact",
		"vue",
	},
	config = true,
}
```

So I started trying to solve this issue and unexpectedly solved it quite easily! 

Not sure why I couldn't change the filetype through configuration. If possible, I hope you can help me with this!.
Also, I hope you can accept this PR!